### PR TITLE
FIX: updated payload for upload scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Fastest Tiktok AutoUploader using Requests, not ~~Selenium~~
 
 Automatically Uploads to Tiktok with 1 command and within 3 seconds.
 
-[Working as of 18th Dec 2024]
+[Working as of 20th Dec 2024]
 
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white&style=flat-square)]([https://www.linkedin.com/in/isaac-kogan-5a45b9193/](https://www.linkedin.com/in/michael-p-88b015200/) )
 [![HitCount](https://hits.dwyl.com/makiisthenes/TiktokAutoUploader.svg?style=flat)](http://hits.dwyl.com/makiisthenes/https://githubcom/makiisthenes/TiktokAutoUploader)

--- a/tiktok_uploader/tiktok.py
+++ b/tiktok_uploader/tiktok.py
@@ -209,7 +209,8 @@ def upload_video(session_user, video, title, schedule_time=0, allow_comment=1, a
 					"allow_duet": 1,
 					"allow_stitch": 1,
 					"allow_comment": 1
-				}
+				},
+				"schedule_time": schedule_time + int(time.time())
 			}
 		],
 		"single_post_req_list": [
@@ -227,8 +228,7 @@ def upload_video(session_user, video, title, schedule_time=0, allow_comment=1, a
 			}
 		]
 	}
-	if schedule_time:
-		data["upload_param"]["schedule_time"] = schedule_time + int(time.time())
+
 	uploaded = False
 	while True:
 		mstoken = session.cookies.get("msToken")


### PR DESCRIPTION
I had issues scheduling reels, so I checked the payload that TikTok accepts and found that schedule_time is not used in `upload_params` but in `feature_common_info_list`.

![Screenshot_1](https://github.com/user-attachments/assets/4d258513-56d0-4ec6-893f-925963818000)

