### PR TITLE
Allow configurable Chrome profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ dmypy.json
 # Personal Development Files
 CookiesDir/
 VideosDirPath/
+/ChromeProfile/
 *.cookie
 output/
 *.mp4

--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ python3 cli.py login -n my_username
 
 A Chrome browser window will open. Log into your TikTok account, and the session will be saved automatically once detected.
 
+To reuse an existing Chrome login session, set `MCVM_CHROME_USER_DATA_DIR` to
+the Chrome user-data directory before running the login command. Set
+`MCVM_CHROME_PROFILE` when the session is stored in a profile other than
+`Default`:
+
+```bash
+export MCVM_CHROME_USER_DATA_DIR="/path/to/chrome/user-data"
+export MCVM_CHROME_PROFILE="Profile 1"
+python3 cli.py login -n my_username
+```
+
+Close Chrome instances using that profile before starting the uploader. Browser
+profiles contain sensitive session data and should never be committed.
+
 ### 2. Upload a video
 
 **From a local file:**

--- a/tiktok_uploader/Browser.py
+++ b/tiktok_uploader/Browser.py
@@ -42,6 +42,14 @@ class Browser:
         # Proxies not supported on login.
         # if WITH_PROXIES:
         #     options.add_argument('--proxy-server={}'.format(PROXIES[0]))
+        # Optional: reuse an existing (already-logged-in) Chrome profile so
+        # login inherits the session instead of prompting for a manual sign-in.
+        user_data_dir = os.getenv("MCVM_CHROME_USER_DATA_DIR")
+        if user_data_dir:
+            options.add_argument(f"--user-data-dir={user_data_dir}")
+            options.add_argument(
+                f"--profile-directory={os.getenv('MCVM_CHROME_PROFILE', 'Default')}"
+            )
         self._driver = uc.Chrome(options=options, version_main=_get_chrome_major_version())
         self.with_random_user_agent()
 


### PR DESCRIPTION
## What changed

- allow the login browser to reuse a Chrome user-data directory through `MCVM_CHROME_USER_DATA_DIR`
- optionally select a named profile through `MCVM_CHROME_PROFILE` (default: `Default`)
- document the environment variables and profile-locking precaution
- ignore the root-level `ChromeProfile/` directory so sensitive browser state is not committed

## Why

The login browser always launched with a fresh profile, so an existing authenticated Chrome session could not be reused. Supplying the profile through environment variables keeps the default behavior unchanged while enabling opt-in session reuse.

## Impact

Users who do not set either variable see no behavior change. Users who opt in should close other Chrome instances using the selected profile before launching the uploader.

## Checks

- `python -m compileall -q tiktok_uploader/Browser.py`
- isolated mock-driver checks for unset, default-profile, and named-profile configurations
- `git check-ignore -v ChromeProfile/profile-data`
- CRLF-aware `git diff --check`
